### PR TITLE
use native request Location method

### DIFF
--- a/app/utils/nativeGeolocation.js
+++ b/app/utils/nativeGeolocation.js
@@ -2,7 +2,7 @@ var geolocation = require("nativescript-geolocation");
 module.exports = {
 	getLocation: function(fn) {
 		if (!geolocation.isEnabled()) {
-			geolocation.enableLocationRequest();
+			iosLocationManager.requestWhenInUseAuthorization();
 			getLocation(fn);
 		}
 		else {


### PR DESCRIPTION
As in
```
function enableLocationRequest(always) {
if (Number(platformModule.device.osVersion) >= 8.0) {
var iosLocationManager = CLLocationManager.alloc().init();
if (always) {
iosLocationManager.requestAlwaysAuthorization();
}
else {
iosLocationManager.requestWhenInUseAuthorization();
}
}
}
```

platformModule.device.osVersion giving NAN hence we have to directly use
native way to request access